### PR TITLE
fix: Changing typo Funtion to Function

### DIFF
--- a/i18n/en/docusaurus-plugin-content-docs-solidity-start/current/03_Function/readme.md
+++ b/i18n/en/docusaurus-plugin-content-docs-solidity-start/current/03_Function/readme.md
@@ -1,5 +1,5 @@
 ---
-title: 3. Funtion
+title: 3. Function
 tags:
   - solidity
   - basic


### PR DESCRIPTION
in Chapter 3 there is a typo on Function word, this PR changes it from Funtion to Function