### PR TITLE
fix: wallet address show the first six and the last four;

### DIFF
--- a/src/utils/truncation.ts
+++ b/src/utils/truncation.ts
@@ -1,11 +1,11 @@
 const truncation = (
   value: string = "",
-  prefix = 5,
+  prefix = 6,
   suffix = 4,
   flag = "***",
 ) => {
   const preValue = value.slice(0, prefix);
-  const sufValue = value.slice(value.length - 1 - suffix, value.length - 1);
+  const sufValue = value.slice(value.length - suffix, value.length);
   return `${preValue}${flag}${sufValue}`;
 };
 export default truncation;


### PR DESCRIPTION
修改目前地址显示丢失最后一位问题；并统一格式：显示前6（含0x）后4位；