### PR TITLE
43/44章节教学合约中导入`IERC20`接口

### DIFF
--- a/docs/solidity-103/43_TokenVesting/readme.md
+++ b/docs/solidity-103/43_TokenVesting/readme.md
@@ -44,7 +44,9 @@ tags:
 - `ERC20Released`：提币事件，当受益人提取释放代币时释放。
 
 ```solidity
-
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 contract TokenVesting {
     // 事件
     event ERC20Released(address indexed token, uint256 amount); // 提币事件

--- a/docs/solidity-103/44_TokenLocker/readme.md
+++ b/docs/solidity-103/44_TokenLocker/readme.md
@@ -54,6 +54,11 @@ tags:
 - `Release`：代币释放事件，在受益人取出代币时释放，记录记录受益人地址，代币地址，释放代币时间，和代币数量。
 
 ```solidity
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+contract TokenVesting {
     // 事件
     event TokenLockStart(address indexed beneficiary, address indexed token, uint256 startTime, uint256 lockTime);
     event Release(address indexed beneficiary, address indexed token, uint256 releaseTime, uint256 amount);


### PR DESCRIPTION
Solidity 103 
由于没有导入`IERC20`接口复制教程代码会报错。以下是本次改动点。
第43章节中教学合约中补充导入`IERC20`接口，第44章节中补充合约定义和`IERC20`接口。
