### PR TITLE
[fix] 修复Solidity-103, 34课 ERC721 文档与示例代码不相符的问题.

### DIFF
--- a/docs/solidity-103/34_ERC721/readme.md
+++ b/docs/solidity-103/34_ERC721/readme.md
@@ -139,6 +139,14 @@ interface IERC721 is IERC165 {
 ```solidity
 // ERC721接收者接口：合约必须实现这个接口来通过安全转账接收ERC721
 interface IERC721Receiver {
+    /**
+     * @dev 每个 {IERC721} `tokenId` 通过 {IERC721-safeTransferFrom} 由 `operator` 从 `from` 转移到
+     * 该合约时，该函数会被调用。
+     *
+     * 该函数必须返回其 Solidity selector 以确认代币的转账。
+     * 如果返回了其他值，或者 tokenId 接收者没有实现该接口，则转账将被回滚。
+     *
+     */
     function onERC721Received(
         address operator,
         address from,
@@ -209,7 +217,7 @@ import "./IERC721Receiver.sol";
 import "./IERC721Metadata.sol";
 import "./String.sol";
 
-contract ERC721 is IERC721, IERC721Metadata{
+contract ERC721 is IERC721, IERC165, IERC721Metadata{
     using Strings for uint256; // 使用String库，
 
     // Token名称


### PR DESCRIPTION
## 问题
### 文档与代码不相符
Solidity-103 [34课 ERC271](https://www.wtf.academy/docs/solidity-103/ERC721/) 文档描述 :
> ERC721主合约实现了IERC721，IERC165和IERC721Metadata定义的所有功能，包含4个状态变量和17个函数:

但示例代码只声明了 `IERC721` 和 `IERC721Metadata` 接口, 并没有声明`IERC165`:

```solidity

contract ERC721 is IERC721, IERC721Metadata{
...
    // 实现IERC165接口supportsInterface
    function supportsInterface(bytes4 interfaceId)
        external
        pure
        override
        returns (bool)
    {
        return
            interfaceId == type(IERC721).interfaceId ||
            interfaceId == type(IERC165).interfaceId ||
            interfaceId == type(IERC721Metadata).interfaceId;
    }
...
}
```
### 缺失上下文信息, 函数理解有难度

> ERC721利用_checkOnERC721Received来确保目标合约实现了onERC721Received()函数（返回onERC721Received的selector)

```solidity
function _checkOnERC721Received(
    address operator,
    address from,
    address to,
    uint256 tokenId,
    bytes memory data
) internal {
    if (to.code.length > 0) {
        try IERC721Receiver(to).onERC721Received(operator, from, tokenId, data) returns (bytes4 retval) {
            if (retval != IERC721Receiver.onERC721Received.selector) {
                // Token rejected
                revert IERC721Errors.ERC721InvalidReceiver(to);
            }
        } catch (bytes memory reason) {
        }
    }
}
```
`_checkOnERC721Received` 通过检查 `onERC721Received`的selector 来判断是否实现了`OnERC721Received`, 但是并没有提供上下文说明为什么可以这么判断, 不便于初学者理解

## 解决方案
1. 更新示例代码，保证文档与示例代码相符
2. 增加 `OnERC721Received` 函数的注释，以解释为什么可以通过"返回onERC721Received的selector"来判断是否实现了`IERC721Receiver`接口