### PR TITLE
[Fix] Solidity 103, Lession 37, Change the visibility of `recoverSigner` function and `verify` function from internal to public

### DIFF
--- a/docs/solidity-103/37_Signature/readme.md
+++ b/docs/solidity-103/37_Signature/readme.md
@@ -141,7 +141,7 @@ print(f"签名：{signed_message['signature'].hex()}")
 
 ```solidity
     // @dev 从_msgHash和签名_signature中恢复signer地址
-    function recoverSigner(bytes32 _msgHash, bytes memory _signature) internal pure returns (address){
+    function recoverSigner(bytes32 _msgHash, bytes memory _signature) public pure returns (address){
         // 检查签名长度，65是标准r,s,v签名的长度
         require(_signature.length == 65, "invalid signature length");
         bytes32 r;
@@ -182,7 +182,7 @@ _signature：0x390d704d7ab732ce034203599ee93dd5d3cb0d4d1d7c600ac11726659489773d5
      * _signature为签名
      * _signer为签名地址
      */
-    function verify(bytes32 _msgHash, bytes memory _signature, address _signer) internal pure returns (bool) {
+    function verify(bytes32 _msgHash, bytes memory _signature, address _signer) public pure returns (bool) {
         return recoverSigner(_msgHash, _signature) == _signer;
     }
 ```


### PR DESCRIPTION
## 问题

在Solidity 103 的[第37课数字签名](https://www.wtf.academy/docs/solidity-103/Signature/)中, 讲解到「步骤4通过签名和消息恢复公钥」和「步骤5 对比公钥并验证签名」, 通过截图展示了在Remix IDE 上 调用 `recoverSigner` 函数和 `verify` 函数的过程:

![](https://www.wtf.academy/assets/images/37-8-50f993208c23bea33eacd5ed18de69ff.png)

![](https://www.wtf.academy/assets/images/37-9-2e2029b1978cafb7cd211511f2769082.png)

但是 `recoverSigner` 和 `verify` 函数都被声明成 `internal` 函数，`internal` 函数是无论从合约外被调用的，即使是使用 Remix IDE进行调试

```solidity
    // @dev 从_msgHash和签名_signature中恢复signer地址
    function recoverSigner(bytes32 _msgHash, bytes memory _signature) internal pure returns (address){
    }

    /**
     * @dev 通过ECDSA，验证签名地址是否正确，如果正确则返回true
     * _msgHash为消息的hash
     * _signature为签名
     * _signer为签名地址
     */
    function verify(bytes32 _msgHash, bytes memory _signature, address _signer) internal pure returns (bool) {
        return recoverSigner(_msgHash, _signature) == _signer;
    }
```

## 解决方案

修改 `recoverSigner` 和 `verify` 函数的可见性，从 `internal` 修改成 `public`, 从而使截图与代码实际行为一致.

另外一个解决方法是在课程中加以强调，说明是为了方便调试所以改成 `public`, 实际应该是 `internal`.
